### PR TITLE
Feature/auto download hmda data

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,25 +519,19 @@ cd ml-final
 
 ### 6.3. Data Preparation
 
-Run the scripts in the following order to collect and prepare the dataset:
+Run these commands to prepare the dataset:
 
-1. Download Raw Data: Fetches 2023 HMDA data for Big 4 TX counties.
-
-```
-python3 src/data/hmda_loader.py
-```
-
-2. Clean Data: Performs preprocessing and prevents data leakage.
-
-```
-python3 src/data/clean_hmda.py
+```bash
+python3 src/data/clean_hmda.py    # Downloads (if needed) and cleans data
+python3 src/data/split_data.py    # Splits data: creates train.csv and test.csv in data/split/
 ```
 
-3. Split Data: Creates train.csv and test.csv in data/split/.
+The `clean_hmda.py` script will automatically download raw data from the CFPB API if it's missing.
 
-```
-python3 src/data/split_data.py
-```
+⏱️ **First run:** 2-5 minutes (downloads ~500MB raw data)  
+⏱️ **Subsequent runs:** < 1 minute (uses cached data)
+
+*Note: Raw data is too large for GitHub, so it is downloaded programmatically from the CFPB API on demand.*
 
 ### 6.4 Run the code
 ```

--- a/src/data/clean_hmda.py
+++ b/src/data/clean_hmda.py
@@ -107,7 +107,9 @@ def clean_hmda_data(input_path):
     return df
 
 if __name__ == "__main__":
-    # Robust Path Resolution
+    import subprocess
+    import sys
+    
     current_script_path = os.path.abspath(__file__)
     project_root = os.path.dirname(os.path.dirname(os.path.dirname(current_script_path)))
     
@@ -115,6 +117,26 @@ if __name__ == "__main__":
     raw_data_path = os.path.join(project_root, 'data/raw/hmda_raw_2023_TX_big4.csv')
     clean_data_dir = os.path.join(project_root, 'data/clean')
     output_data_path = os.path.join(clean_data_dir, 'hmda_cleaned.csv')
+
+    # ===== AUTO-DOWNLOAD IF MISSING =====
+    if not os.path.exists(raw_data_path):
+        print("⚠️  Raw data not found. Downloading from CFPB API...")
+        print("   This may take 2-5 minutes...")
+        
+        hmda_loader_path = os.path.join(project_root, 'src/data/hmda_loader.py')
+        result = subprocess.run(
+            [sys.executable, hmda_loader_path],
+            cwd=project_root
+        )
+        
+        if result.returncode != 0:
+            print("❌ Download failed! Check your internet connection.")
+            sys.exit(1)
+        
+        print("✓ Download complete!")
+    else:
+        print("✓ Raw data found. Proceeding with cleaning...")
+    # ===== END =====
 
     # Ensure output directory exists
     os.makedirs(clean_data_dir, exist_ok=True)
@@ -124,4 +146,4 @@ if __name__ == "__main__":
     if cleaned_df is not None:
         print(f"Step 5: Saving cleaned data to {output_data_path}...")
         cleaned_df.to_csv(output_data_path, index=False)
-        print("Success!")
+        print("✓ Success!") 


### PR DESCRIPTION
What this does
- Automatically downloads raw HMDA data if it's missing
- Users can now run `python3 src/data/clean_hmda.py` without manual setup

Changes made
1. Modified `src/data/clean_hmda.py` to check for raw data before processing
2. Auto-runs `hmda_loader.py` if data doesn't exist
3. Updated README.md Section 6.3 with simplified instructions